### PR TITLE
[FIX] 바로가기 버튼 클릭 이후 모달 닫히도록 수정

### DIFF
--- a/components/room/modal/StudyRoomCreateInfoModal.jsx
+++ b/components/room/modal/StudyRoomCreateInfoModal.jsx
@@ -25,7 +25,15 @@ function StudyRoomCreateInfoModal({ success, error, close, roomId }) {
           <Title>방 만들기 완료</Title>
           <Description>방 만들기가 완료되었습니다.</Description>
           <ModalButton title={'닫기'} onPress={close} />
-          <ModalButton title={'바로가기'} onPress={() => navigation.navigate('study-room', { roomId })} highlight />
+          <ModalButton
+            title={'바로가기'}
+            onPress={() => {
+              close();
+              navigation.popToTop();
+              navigation.navigate('study-room', { roomId });
+            }}
+            highlight
+          />
         </Container>
       </SmallInfoModal>
     );


### PR DESCRIPTION
 ## 어떤 이유로 MR를 하셨나요?
 - [ ] feature 병합()
 - [x] 버그 수정(아래에 issue #를 남겨주세요)
 - [ ] 코드 개선
 - [ ] 코드 수정
 - [ ] 배포
 - [ ] 기타(아래에 자세한 내용 기입해주세요)
 
 ## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요
 - 방 만들기 이후 바로가기 버튼 누르면 모달창 안닫히는거 수정
 - 방으로 이동 후 뒤로가기 누르면 홈 화면이 나오도록 수정
     
 ## MR하기 전에 확인해주세요
 - [x] 로컬테스트를 진행하셨나요?
 - [x] 머지할 브랜치를 확인하셨나요?
     
 ## 관련 이슈 번호
 - #48 